### PR TITLE
Fix some bugs from v1.1.0

### DIFF
--- a/ndr.lib.mk
+++ b/ndr.lib.mk
@@ -1,7 +1,7 @@
 SRCDIR := $(NBE_ROOT)/$S
 
 .PHONY: build
-build: $(HDRS) $(EXTOBJS) $(INCS) $(SRCS) lklib
+build: $(HDRS) $(EXTOBJS) $(SRCS) $(INCS) lklib
 
 .PHONY: depset
 depset: mkdir $(HDRS)
@@ -20,13 +20,13 @@ $(HDRS):
 $(EXTOBJS):
 	$(eval LNKLIST += $(wildcard  $(NBE_MK_OBJPATH)/$@/*.o))
 
-$(INCHDR):
-	@cp -f $(SRCDIR)/$@ $(NBE_INCPATH)/$(LIB).h
-
 $(SRCS)::
 	@gcc -c $(SRCDIR)/$@ -I$(NBE_INCPATH) -I$(NBE_MK_INCPATH) $(CFLAGS) $(EXTRA_CFLAGS)
 	@cp -f $(basename $@).o $(NBE_MK_LOBJPATH)
 	$(eval LNKLIST += $(basename $@).o)
+
+$(INCS):
+	@cp -f $(SRCDIR)/$@ $(NBE_INCPATH)
 
 lklib:
 	@ar rcs $(NBE_LIBPATH)/lib$(LIB).a $(LNKLIST)

--- a/ndr.test.subcomp/nts.h
+++ b/ndr.test.subcomp/nts.h
@@ -6,37 +6,37 @@
 
 #define NTS_INTERNAL_NULL                  (void *)0
 
-#if defined     __GNUC__
-    #define nts_internal_forceinline__     __attribute__((always_inline))
-    #define nts_internal_likely(x)         __builtin_expect((x),1)
-    #define nts_internal_unlikely(x)       __builtin_expect((x),0)
-    #define NTS_INTERNAL_CSTR_FILE         __FILE__
-    #define NTS_INTERNAL_CSTR_LINE         __LINE__
-    #define NTS_INTERNAL_CSTR_FUNC         __func__
-    #define NTS_INTERNAL_CSTR_COMPDATE     __DATE__
-    #define NTS_INTERNAL_CSTR_COMPTIME     __TIME__
-    #define NTS_INTERNAL_CSTR_FILETIME     __TIMESTAMP__
-#elif defined   __clang__
-#   if defined  __ICC
+#if defined     GNUC
+	#define nts_internal_forceinline		__attribute__((always_inline))
+	#define nts_internal_likely(x)			__builtin_expect((x),1)
+	#define nts_internal_unlikely(x)		__builtin_expect((x),0)
+	#define NTS_INTERNAL_CSTR_FILE			__FILE__
+	#define NTS_INTERNAL_CSTR_LINE			__LINE__
+	#define NTS_INTERNAL_CSTR_FUNC			__func__
+	#define NTS_INTERNAL_CSTR_COMPDATE		__DATE__
+	#define NTS_INTERNAL_CSTR_COMPTIME		__TIME__
+	#define NTS_INTERNAL_CSTR_FILETIME		__TIMESTAMP__
+#elif defined   clang
+#   if defined  ICC
 #   else
 #   endif
 #elif defined   _MSC_VER
 #else
-    #define nts_internal_forceinline__
-    #define nts_internal_likely(x)         (x)
-    #define nts_internal_unlikely(x)       (x)
-    #define NTS_INTERNAL_CSTR_FILE         NTS_INTERNAL_NULL
-    #define NTS_INTERNAL_CSTR_LINE         0
-    #define NTS_INTERNAL_CSTR_FUNC         NTS_INTERNAL_NULL
-    #define NTS_INTERNAL_CSTR_COMPDATE     NTS_INTERNAL_NULL
-    #define NTS_INTERNAL_CSTR_COMPTIME     NTS_INTERNAL_NULL
-    #define NTS_INTERNAL_CSTR_FILETIME     NTS_INTERNAL_NULL
+	#define nts_internal_forceinline
+	#define nts_internal_likely(x)			(x)
+	#define nts_internal_unlikely(x)		(x)
+	#define NTS_INTERNAL_CSTR_FILE			NTS_INTERNAL_NULL
+	#define NTS_INTERNAL_CSTR_LINE			0
+	#define NTS_INTERNAL_CSTR_FUNC			NTS_INTERNAL_NULL
+	#define NTS_INTERNAL_CSTR_COMPDATE		NTS_INTERNAL_NULL
+	#define NTS_INTERNAL_CSTR_COMPTIME		NTS_INTERNAL_NULL
+	#define NTS_INTERNAL_CSTR_FILETIME		NTS_INTERNAL_NULL
 #endif
 
-#ifdef nts_internal_forceinline__
-    #define nts_internal_hdrfunc__         static inline nts_internal_forceinline__
+#ifdef nts_internal_forceinline
+	#define nts_internal_hdrfunc         static inline nts_internal_forceinline
 #else
-    #define nts_internal_hdrfunc__         static inline
+	#define nts_internal_hdrfunc         static inline
 #endif
 
 #define NTS_INTERNAL_STYLE_RESET       "\x1b[0m"
@@ -61,24 +61,24 @@
 
 enum nts_internal_verbose_level
 {
-    NTS_INTERNAL_LVLNONE	= 0b0000000,
-    NTS_INTERNAL_LVLIGN		= 0b0000001,
+	NTS_INTERNAL_LVLNONE	= 0b0000000,
+	NTS_INTERNAL_LVLIGN		= 0b0000001,
 	NTS_INTERNAL_LVLRSLT	= 0b0000010,
-    NTS_INTERNAL_LVLINFO	= 0b0000100,
-    NTS_INTERNAL_LVLEXPR	= 0b0001000,
-    NTS_INTERNAL_LVLSPEC	= 0b0010000,
-    NTS_INTERNAL_LVLCONT	= 0b0100000,
-    NTS_INTERNAL_LVLEXIT	= 0b1000000,
+	NTS_INTERNAL_LVLINFO	= 0b0000100,
+	NTS_INTERNAL_LVLEXPR	= 0b0001000,
+	NTS_INTERNAL_LVLSPEC	= 0b0010000,
+	NTS_INTERNAL_LVLCONT	= 0b0100000,
+	NTS_INTERNAL_LVLEXIT	= 0b1000000,
 };
-typedef enum nts_internal_verbose_level _NTSLVL_;
+typedef enum nts_internal_verbose_level NTS_LVLENUM;
 
 #ifdef NBE_STRICT_TEST
-    #define NTS_LVLNORMAL	NTS_INTERNAL_LVLRSLT | NTS_INTERNAL_LVLINFO | NTS_INTERNAL_LVLEXPR  | NTS_INTERNAL_LVLEXIT
+	#define NTS_LVLNORMAL	NTS_INTERNAL_LVLRSLT | NTS_INTERNAL_LVLINFO | NTS_INTERNAL_LVLEXPR  | NTS_INTERNAL_LVLEXIT
 	#define NTS_LVLSIMPLE	NTS_INTERNAL_LVLRSLT | NTS_INTERNAL_LVLINFO | NTS_INTERNAL_LVLEXIT
 	#define NTS_LVLRESULT	NTS_INTERNAL_LVLRSLT | NTS_INTERNAL_LVLEXIT
 	#define NTS_LVLSILENT	NTS_INTERNAL_LVLEXIT
 #else
-    #define NTS_LVLNORMAL	NTS_INTERNAL_LVLRSLT | NTS_INTERNAL_LVLINFO | NTS_INTERNAL_LVLEXPR
+	#define NTS_LVLNORMAL	NTS_INTERNAL_LVLRSLT | NTS_INTERNAL_LVLINFO | NTS_INTERNAL_LVLEXPR
 	#define NTS_LVLSIMPLE	NTS_INTERNAL_LVLRSLT | NTS_INTERNAL_LVLINFO
 	#define NTS_LVLRESULT	NTS_INTERNAL_LVLRSLT
 	#define NTS_LVLSILENT	NTS_INTERNAL_LVLNONE
@@ -86,140 +86,155 @@ typedef enum nts_internal_verbose_level _NTSLVL_;
 
 struct nts_internal_testcase_info
 {
-    int f_stop;
-    int f_spec;
-    unsigned long test_cnt;
-    unsigned long ignore_cnt;
-    unsigned long fail_cnt;
+	int f_stop;
+	int f_spec;
+	unsigned long test_cnt;
+	unsigned long ignore_cnt;
+	unsigned long fail_cnt;
 };
-typedef struct nts_internal_testcase_info * _NTSTC_;
+typedef struct nts_internal_testcase_info * NTS_STRUCT;
 
-nts_internal_hdrfunc__ void nts_internal_assert(
-    int expr_result, const char *__expr,
-    const char * __file, unsigned int __line,
-    _NTSTC_ __tc, _NTSLVL_ __verbosity )
+nts_internal_hdrfunc void nts_internal_assert(
+	int expr_result, const char *expr,
+	const char * file, unsigned int line,
+	NTS_STRUCT tc, NTS_LVLENUM verbosity )
 {
-    if ( nts_internal_unlikely( __verbosity & NTS_INTERNAL_LVLIGN ) )
-    {
-        __tc->ignore_cnt++;
-        goto assert_out;
-    }
+	if ( nts_internal_unlikely( verbosity & NTS_INTERNAL_LVLIGN ) )
+	{
+		tc->ignore_cnt++;
+		goto assert_out;
+	}
 
-	if ( __verbosity & NTS_INTERNAL_LVLRSLT )
+	if ( verbosity & NTS_INTERNAL_LVLRSLT )
 	{
 		printf( "[#] ");
 	}
 
-    if ( __verbosity & NTS_INTERNAL_LVLINFO )
-    {
-        printf( "%s(%u) : ", __file ? __file : "unkfile", __line );
-    }
+	if ( verbosity & NTS_INTERNAL_LVLINFO )
+	{
+		printf( "%s(%u) : ", file ? file : "unkfile", line );
+	}
 
-	if ( __verbosity & NTS_INTERNAL_LVLRSLT )
+	if ( verbosity & NTS_INTERNAL_LVLRSLT )
 	{
 		printf( "%s%s%s%s\n", NTS_INTERNAL_FONT_BOLD,
 			expr_result ? NTS_INTERNAL_COLOR_GREEN : NTS_INTERNAL_COLOR_RED,
 			expr_result ? "PASS" : "FAILED", NTS_INTERNAL_STYLE_RESET );
 	}
 
-    if ( __verbosity & NTS_INTERNAL_LVLEXPR )
-    {
-        printf( "\tExpression : %s%s%s\n",
-            NTS_INTERNAL_COLOR_CYAN, __expr, NTS_INTERNAL_STYLE_RESET );
-    }
+	if ( verbosity & NTS_INTERNAL_LVLEXPR )
+	{
+		printf( "\tExpression : %s%s%s\n",
+			NTS_INTERNAL_COLOR_CYAN, expr, NTS_INTERNAL_STYLE_RESET );
+	}
 
-    if ( __verbosity & NTS_INTERNAL_LVLSPEC )
-    {
-        __tc->f_spec = 1;
-    }
+	if ( verbosity & NTS_INTERNAL_LVLSPEC )
+	{
+		tc->f_spec = 1;
+	}
 
-    if ( !(expr_result) )
-    {
-        if( !(__verbosity & NTS_INTERNAL_LVLCONT) )
-        {
+	if ( !(expr_result) )
+	{
+		if( !(verbosity & NTS_INTERNAL_LVLCONT) )
+		{
 #ifdef NBE_STRICT_TEST
-            if ( __verbosity & NTS_INTERNAL_LVLEXIT )
-            {
-                exit( NTS_EXITCODE_TFALSE );
-            }
+			if ( verbosity & NTS_INTERNAL_LVLEXIT )
+			{
+				exit( NTS_EXITCODE_TFALSE );
+			}
 #endif
-            __tc->f_stop = NTS_INTERNAL_LVLIGN;
-        }
-        __tc->fail_cnt++;
-    }
+			tc->f_stop = NTS_INTERNAL_LVLIGN;
+		}
+		tc->fail_cnt++;
+	}
 
-    if ( !(__tc->f_spec) && (__verbosity & NTS_INTERNAL_LVLRSLT) )
-    {
-        printf( "\n" );
-    }
+	if ( !(tc->f_spec) && (verbosity & NTS_INTERNAL_LVLRSLT) )
+	{
+		printf( "\n" );
+	}
 
 assert_out:
-    __tc->test_cnt++;
-    return;
+	tc->test_cnt++;
+	return;
 }
 
-nts_internal_hdrfunc__ void nts_internal_report_tc( const char * __tcn, _NTSTC_ __tc )
+nts_internal_hdrfunc void nts_internal_report_tc( const char * tcn, NTS_STRUCT tc )
 {
-    double coverage = 0.0;
+	double pass_rate = 0.0;
 
-    printf("\n%s[*] TESTCASE Coverage report%s\n",
-        NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET );
-    printf(" %s|%s TC Name  : %s%s%s\n",
-        NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET, NTS_INTERNAL_FONT_BOLD,
-        __tcn, NTS_INTERNAL_STYLE_RESET );
-    printf(" %s|%s Result   : %s%s%s%s\n",
-        NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET, NTS_INTERNAL_FONT_BOLD,
-        __tc->fail_cnt ? NTS_INTERNAL_COLOR_RED : NTS_INTERNAL_COLOR_GREEN,
-        __tc->f_stop ? "INTERRUPTED" : (__tc->fail_cnt ? "FAILED" : "PASS"), NTS_INTERNAL_STYLE_RESET );
-    printf(" %s|%s Tested   : %lu%s\n", NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
-        __tc->test_cnt, NTS_INTERNAL_COLOR_RESET );
-    printf(" %s|%s Passed   : %lu%s\n", NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
-        __tc->test_cnt - __tc->fail_cnt, NTS_INTERNAL_COLOR_RESET );
-    printf(" %s|%s Failed   : %lu%s\n",NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
-        __tc->fail_cnt, NTS_INTERNAL_COLOR_RESET );
-    printf(" %s|%s Ignored  : %lu%s\n", NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
-        __tc->ignore_cnt, NTS_INTERNAL_COLOR_RESET );
+	printf("\n%s[*] TESTCASE Report%s\n",
+		NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET );
+	printf(" %s|%s TC Name   : %s%s%s\n",
+		NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET, NTS_INTERNAL_FONT_BOLD,
+		tcn, NTS_INTERNAL_STYLE_RESET );
+	printf(" %s|%s Result    : %s%s%s%s\n",
+		NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET, NTS_INTERNAL_FONT_BOLD,
+		tc->fail_cnt ? NTS_INTERNAL_COLOR_RED : NTS_INTERNAL_COLOR_GREEN,
+		tc->f_stop ? "INTERRUPTED" : (tc->fail_cnt ? "FAILED" : "PASS"), NTS_INTERNAL_STYLE_RESET );
+	printf(" %s|%s Tested    : %lu%s\n", NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
+		tc->test_cnt, NTS_INTERNAL_COLOR_RESET );
+	printf(" %s|%s Passed    : %lu%s\n", NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
+		tc->test_cnt - tc->fail_cnt, NTS_INTERNAL_COLOR_RESET );
+	printf(" %s|%s Failed    : %lu%s\n",NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
+		tc->fail_cnt, NTS_INTERNAL_COLOR_RESET );
+	printf(" %s|%s Ignored   : %lu%s\n", NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
+		tc->ignore_cnt, NTS_INTERNAL_COLOR_RESET );
 
-    coverage = __tc->f_stop ? -1.0 : (__tc->fail_cnt ? (100 - (100 / (__tc->test_cnt / __tc->fail_cnt))) : 100 );
-    if ( coverage < 0 )
-    {
-        printf(" %s|%s Coverage : %s%s%s%s\n", NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
-            NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_COLOR_MAGENTA, "unknown" , NTS_INTERNAL_COLOR_RESET );
-    }
-    else
-    {
-        if ( coverage < 30 )
-        {
-            printf(" %s|%s Coverage : %s%s%.2lf%%%s\n",
-                NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
-                NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_COLOR_RED, coverage , NTS_INTERNAL_COLOR_RESET );
-        }
-        else if ( coverage < 70 )
-        {
-            printf(" %s|%s Coverage : %s%s%.2lf%%%s\n",
-                NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
-                NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_COLOR_MAGENTA, coverage , NTS_INTERNAL_COLOR_RESET );
-        }
-        else if ( coverage < 100 )
-        {
-            printf(" %s|%s Coverage : %s%s%.2lf%%%s\n",
-                NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
-                NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_COLOR_YELLOW, coverage , NTS_INTERNAL_COLOR_RESET );
-        }
-        else
-        {
-            printf(" %s|%s Coverage : %s%s%.2lf%%%s\n",
-                NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
-                NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_COLOR_GREEN, coverage , NTS_INTERNAL_COLOR_RESET );
-        }
-    }
-    printf("%s[*]%s\n\n", NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET );
+	if ( tc->f_stop )
+	{
+		pass_rate = -1.0;
+	}
+	else
+	{
+		if ( tc->fail_cnt )
+		{
+			pass_rate = (tc->test_cnt ^ tc->fail_cnt) ?  (100.0 - ((tc->fail_cnt * 100.0) / tc->test_cnt)) : 0.0;
+		}
+		else
+		{
+			pass_rate = 100.0;
+		}
+	}
+
+	if ( pass_rate < 0 )
+	{
+		printf(" %s|%s Pass Rate : %s%s%s%s\n", NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
+			NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_COLOR_MAGENTA, "unknown" , NTS_INTERNAL_COLOR_RESET );
+	}
+	else
+	{
+		if ( pass_rate < 30 )
+		{
+			printf(" %s|%s Pass Rate : %s%s%.2lf%%%s\n",
+				NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
+				NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_COLOR_RED, pass_rate , NTS_INTERNAL_COLOR_RESET );
+		}
+		else if ( pass_rate < 70 )
+		{
+			printf(" %s|%s Pass Rate : %s%s%.2lf%%%s\n",
+				NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
+				NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_COLOR_MAGENTA, pass_rate , NTS_INTERNAL_COLOR_RESET );
+		}
+		else if ( pass_rate < 100 )
+		{
+			printf(" %s|%s Pass Rate : %s%s%.2lf%%%s\n",
+				NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
+				NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_COLOR_YELLOW, pass_rate , NTS_INTERNAL_COLOR_RESET );
+		}
+		else
+		{
+			printf(" %s|%s Pass Rate : %s%s%.2lf%%%s\n",
+				NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET,
+				NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_COLOR_GREEN, pass_rate , NTS_INTERNAL_COLOR_RESET );
+		}
+	}
+	printf("%s[*]%s\n\n", NTS_INTERNAL_FONT_BOLD, NTS_INTERNAL_STYLE_RESET );
 
 #ifdef NBE_STRICT_TEST
-    if ( coverage != 100 )
-    {
-        exit( coverage < 0 ? NTS_EXITCODE_TCFAIL : NTS_EXITCODE_TCINTR );
-    }
+	if ( pass_rate != 100 )
+	{
+		exit( pass_rate < 0 ? NTS_EXITCODE_TCFAIL : NTS_EXITCODE_TCINTR );
+	}
 #endif
 }
 
@@ -234,34 +249,34 @@ nts_internal_hdrfunc__ void nts_internal_report_tc( const char * __tcn, _NTSTC_ 
 #define NTS_INTERNAL_ACCESS_STRC(testcase)             nts_info_ ## testcase
 
 #define NTS_INTERNAL_ASSERT( tc, expr, lvl ) \
-    nts_internal_assert( (expr), NTS_INTERNAL_STRINGIFY(expr), NTS_INTERNAL_CSTR_FILE, NTS_INTERNAL_CSTR_LINE, \
-        &(NTS_INTERNAL_ACCESS_STRC(tc)), lvl | (NTS_INTERNAL_ACCESS_STRC(tc)).f_stop )
+	nts_internal_assert( (expr), NTS_INTERNAL_STRINGIFY(expr), NTS_INTERNAL_CSTR_FILE, NTS_INTERNAL_CSTR_LINE, \
+		&(NTS_INTERNAL_ACCESS_STRC(tc)), lvl | (NTS_INTERNAL_ACCESS_STRC(tc)).f_stop )
 
 #define NTS_INTERNAL_DO_SPECULATE( tc, expr1, expr2, expr1_var, expr2_var ) \
-    do{ \
-        if( (NTS_INTERNAL_ACCESS_STRC(tc)).f_spec ) \
-        { \
-            (NTS_INTERNAL_ACCESS_STRC(tc)).f_spec = 0; \
-            printf( "\tSpeculation result : %s%llu(%s) == %llu(%s)%s\n\n", \
-                NTS_INTERNAL_COLOR_CYAN, expr1, expr1_var, \
-                expr2, expr2_var, NTS_INTERNAL_STYLE_RESET ); \
-        } \
-    }while(0);
+	do{ \
+		if( (NTS_INTERNAL_ACCESS_STRC(tc)).f_spec ) \
+		{ \
+			(NTS_INTERNAL_ACCESS_STRC(tc)).f_spec = 0; \
+			printf( "\tSpeculation result : %s%llu(%s) == %llu(%s)%s\n\n", \
+				NTS_INTERNAL_COLOR_CYAN, expr1, expr1_var, \
+				expr2, expr2_var, NTS_INTERNAL_STYLE_RESET ); \
+		} \
+	}while(0);
 
 #define NTS_INTERNAL_SPECULATE( tc, expr1, expr2, lvl ) \
-    do{ NTS_INTERNAL_ASSERT( tc, NTS_INTERNAL_TESTEQ_EXPR(expr1, expr2), lvl | NTS_INTERNAL_LVLSPEC ); \
-        unsigned long long expr1_var = (unsigned long long)(expr1); \
-        unsigned long long expr2_var = (unsigned long long)(expr2); \
-        NTS_INTERNAL_DO_SPECULATE( tc, expr1_var, expr2_var, NTS_INTERNAL_STRINGIFY(expr1), NTS_INTERNAL_STRINGIFY(expr2) ); \
-    }while(0);
+	do{ NTS_INTERNAL_ASSERT( tc, NTS_INTERNAL_TESTEQ_EXPR(expr1, expr2), lvl | NTS_INTERNAL_LVLSPEC ); \
+		unsigned long long expr1_var = (unsigned long long)(expr1); \
+		unsigned long long expr2_var = (unsigned long long)(expr2); \
+		NTS_INTERNAL_DO_SPECULATE( tc, expr1_var, expr2_var, NTS_INTERNAL_STRINGIFY(expr1), NTS_INTERNAL_STRINGIFY(expr2) ); \
+	}while(0);
 
-#define NTS_DEFINE_TC( testcase )               		extern NTS_INTERNAL_TC_STRC(testcase) ; NTS_INTERNAL_TC_FUNC(testcase)
+#define NTS_DECLARE_TC( testcase )						extern NTS_INTERNAL_TC_STRC(testcase) ; NTS_INTERNAL_TC_FUNC(testcase)
 
-#define NTS_DECLARE_TC( testcase )              		NTS_INTERNAL_TC_STRC(testcase) ; NTS_INTERNAL_TC_FUNC(testcase)
+#define NTS_DEFINE_TC( testcase )						NTS_INTERNAL_TC_STRC(testcase) ; NTS_INTERNAL_TC_FUNC(testcase)
 
-#define NTS_CALL_TC( testcase )                 		nts_tc_ ## testcase ()
+#define NTS_CALL_TC( testcase )							nts_tc_ ## testcase ()
 
-#define NTS_REQUIRE( tc, expr )                 		NTS_INTERNAL_ASSERT( tc, expr, NTS_LVLNORMAL )
+#define NTS_REQUIRE( tc, expr )							NTS_INTERNAL_ASSERT( tc, expr, NTS_LVLNORMAL )
 
 #define NTS_CHECK( tc, expr )							NTS_INTERNAL_ASSERT( tc, expr, NTS_LVLNORMAL | NTS_INTERNAL_LVLCONT )
 


### PR DESCRIPTION
nts: Coverage field of 'NTS_REPORT' does not work.
 - Change expression "Coverage" to "Pass Rate"
 - Fix unexpected output of "Pass Rate"

nts: NTS declaration/definition wording reversed.
 - Fix reversed expression "NTS_DEFINE_TC" and "NTS_DECLARE_TC"

build: build: In static library build, header files must be placed in $INCPA...
 - Fix uncontrolled target "INCHDRS"
 - Change build sequences
  	as-is: (HDRS->EXTOBJS->INCS->SRCS->link)
 	to-be: (HDRS->EXTOBJS->SRCS->INCS->link)
 - Change header files' target directory to $(NBE_MK_INCPATH)

Resolves: #8, #9, #10