### PR TITLE
build: fix ndr.lib.mk build fault

### DIFF
--- a/ndr.lib.mk
+++ b/ndr.lib.mk
@@ -26,7 +26,7 @@ $(SRCS)::
 	@cp -f $(basename $@).o $(NBE_MK_LOBJPATH)
 	$(eval LNKLIST += $(basename $@).o)
 
-$(INCS):
+$(INCS)::
 	@cp -f $(SRCDIR)/$@ $(NBE_INCPATH)
 
 lklib:


### PR DESCRIPTION
- Fix '*** target file '....h' has both : and :: entries. Stop.'

Resolves: #49