### PR TITLE
build: fix negative values in lcovgen

### DIFF
--- a/ndr.covreport.mk
+++ b/ndr.covreport.mk
@@ -17,6 +17,7 @@ lcovlist::
 lcovgen::
 	@echo $(LCOVLIST)
 	@lcov -c -d . -o $(COVAPP)_raw.lcov
+	@sed -i 's/-\([0-9]\+\)/\1/g' $(COVAPP)_raw.lcov
 	@lcov -e $(COVAPP)_raw.lcov $(LCOVLIST) -o $(COVAPP).lcov
 
 lcovhtml::


### PR DESCRIPTION
- Fix `lcov: WARNING: negative counts found in ` errors

Resolves: #61