### PR TITLE
build: Use $(NAME) as the default build identifier.

### DIFF
--- a/ndr.app.mk
+++ b/ndr.app.mk
@@ -1,3 +1,5 @@
+$(APP) ?= $(NAME)
+
 SRCDIR := $(NBE_ROOT)/$S
 LDFLAGS += --as-needed -ldl
 

--- a/ndr.covapp.mk
+++ b/ndr.covapp.mk
@@ -1,3 +1,5 @@
+$(COVAPP) ?= $(NAME)
+
 SUBCOMP += test
 include $(NBE_DIR)/ndr.subcomp.mk
 

--- a/ndr.dpdkapp.mk
+++ b/ndr.dpdkapp.mk
@@ -1,3 +1,5 @@
+$(DPDKAPP) ?= $(NAME)
+
 SRCDIR := $(NBE_ROOT)/$S
 LDFLAGS += --as-needed -ldl
 
@@ -37,4 +39,4 @@ lkapp::
 	@gcc -o $(DPDKAPP).app $(EXTLIST) $(SRCLIST) -L$(NBE_LIBPATH) -L$(NBE_MK_DPDKPATH) $(NBE_LIBS) $(NBE_DPDKLIBS) $(LIBLIST)
 
 cpapp::
-	@cp -f $(DPDKAPP).app $(NBE_APPPATH)
+	cp -f $(DPDKAPP).app $(NBE_APPPATH)

--- a/ndr.dpdkcov.mk
+++ b/ndr.dpdkcov.mk
@@ -1,3 +1,5 @@
+$(DPDKCOV) ?= $(NAME)
+
 SUBCOMP += test
 include $(NBE_DIR)/ndr.subcomp.mk
 
@@ -14,7 +16,7 @@ depset: mkdir $(HDRS)
 
 mkdir::
 	@[ -d $(NBE_COVPATH) ] || mkdir -p $(NBE_COVPATH)
-	@[ -d $(NBE_COVPATH)/$(COVAPP) ] || mkdir -p $(NBE_COVPATH)/$(COVAPP)
+	@[ -d $(NBE_COVPATH)/$(DPDKCOV) ] || mkdir -p $(NBE_COVPATH)/$(DPDKCOV)
 	@[ -d $(NBE_MK_DPDKPATH) ] || mkdir -p $(NBE_MK_DPDKPATH)
 
 $(HDRS)::
@@ -37,19 +39,19 @@ buildlist::
 buildtest::
 	@[ -d $(NBE_DPDKPATH) ] && cp -Lr $(NBE_DPDKPATH)/include/* $(NBE_MK_DPDKPATH)/.
 	@[ -d $(NBE_DPDKPATH) ] && cp -Lr $(NBE_DPDKPATH)/lib/* $(NBE_MK_DPDKPATH)/.
-	@gcc -coverage -o $(COVAPP)_cov $(BUILDLIST) -I$(SRCDIR) -I$(NBE_INCPATH) -I$(NBE_MK_DPDKPATH) -I$(NBE_MK_INCPATH) -L$(NBE_LIBPATH) -L$(NBE_MK_DPDKPATH) $(NBE_LIBS) $(NBE_DPDKLIBS) $(LIBLIST) $(CFLAGS) $(EXTRA_CFLAGS) -DNTS_MAIN_$(COVAPP)
-	@gcc -o $(COVAPP).app $(BUILDLIST) -I$(SRCDIR) -I$(NBE_INCPATH) -I$(NBE_MK_DPDKPATH) -I$(NBE_MK_INCPATH) -L$(NBE_LIBPATH) -L$(NBE_MK_DPDKPATH) $(NBE_LIBS) $(NBE_DPDKLIBS) $(LIBLIST) $(CFLAGS) $(EXTRA_CFLAGS) -DNTS_MAIN_$(COVAPP)
+	@gcc -coverage -o $(DPDKCOV)_cov $(BUILDLIST) -I$(SRCDIR) -I$(NBE_INCPATH) -I$(NBE_MK_DPDKPATH) -I$(NBE_MK_INCPATH) -L$(NBE_LIBPATH) -L$(NBE_MK_DPDKPATH) $(NBE_LIBS) $(NBE_DPDKLIBS) $(LIBLIST) $(CFLAGS) $(EXTRA_CFLAGS) -DNTS_MAIN_$(DPDKCOV)
+	@gcc -o $(DPDKCOV).app $(BUILDLIST) -I$(SRCDIR) -I$(NBE_INCPATH) -I$(NBE_MK_DPDKPATH) -I$(NBE_MK_INCPATH) -L$(NBE_LIBPATH) -L$(NBE_MK_DPDKPATH) $(NBE_LIBS) $(NBE_DPDKLIBS) $(LIBLIST) $(CFLAGS) $(EXTRA_CFLAGS) -DNTS_MAIN_$(DPDKCOV)
 
 gcovlist::
 	$(eval GCOVLIST += $(foreach COVFILE, $(COVLIST), $(shell ls $(NBE_MK_COVPATH)/$(COVFILE).c 2>/dev/null)))
 	$(eval GCOVLIST += $(foreach COVFILE, $(COVLIST), $(shell ls $(NBE_MK_COVPATH)/$(COVFILE).cc 2>/dev/null)))
 
 gcovgen::
-	@cp -f $(COVAPP).app $(NBE_COVPATH)/$(COVAPP).app
-	@./$(COVAPP)_cov $(TESTARGS) > $(COVAPP).result 2>&1
-	@cp -f $(COVAPP).result $(NBE_COVPATH)/$(COVAPP).result
+	@cp -f $(DPDKCOV).app $(NBE_COVPATH)/$(DPDKCOV).app
+	@./$(DPDKCOV)_cov $(TESTARGS) > $(DPDKCOV).result 2>&1
+	@cp -f $(DPDKCOV).result $(NBE_COVPATH)/$(DPDKCOV).result
 	@gcov $(GCOVLIST) -o .
 
 gcovcp::
-	@cp -f $(foreach GCOVFILE, $(GCOVLIST), ./$(notdir $(GCOVFILE)).gcov) $(NBE_COVPATH)/$(COVAPP)
-	@$(NBE_SCRIPTS)/restore_source.sh $(NBE_LOG_PATHLOG) $(NBE_COVPATH)/$(COVAPP)
+	@cp -f $(foreach GCOVFILE, $(GCOVLIST), ./$(notdir $(GCOVFILE)).gcov) $(NBE_COVPATH)/$(DPDKCOV)
+	@$(NBE_SCRIPTS)/restore_source.sh $(NBE_LOG_PATHLOG) $(NBE_COVPATH)/$(DPDKCOV)

--- a/ndr.dpdkobj.mk
+++ b/ndr.dpdkobj.mk
@@ -1,3 +1,5 @@
+$(DPDKOBJ) ?= $(NAME)
+
 SRCDIR := $(NBE_ROOT)/$S
 
 .PHONY: build
@@ -11,7 +13,7 @@ mkdir::
 	@[ -d $(NBE_MK_INCPATH) ] || mkdir -p $(NBE_MK_INCPATH)
 	@[ -d $(NBE_MK_OBJPATH) ] || mkdir -p $(NBE_MK_OBJPATH)
 	@[ -d $(NBE_MK_DPDKPATH) ] || mkdir -p $(NBE_MK_DPDKPATH)
-	@[ -d $(NBE_MK_OBJPATH)/$(OBJ) ] || mkdir -p $(NBE_MK_OBJPATH)/$(OBJ)
+	@[ -d $(NBE_MK_OBJPATH)/$(DPDKOBJ) ] || mkdir -p $(NBE_MK_OBJPATH)/$(DPDKOBJ)
 	@[ -d $(NBE_INCPATH) ] || mkdir -p $(NBE_INCPATH)
 
 $(HDRS)::
@@ -21,4 +23,4 @@ $(HDRS)::
 $(SRCS)::
 	@[ -d $(NBE_DPDKPATH) ] && cp -Lr $(NBE_DPDKPATH)/include/* $(NBE_MK_DPDKPATH)/.
 	@gcc -c $(SRCDIR)/$@ -I$(NBE_INCPATH) -I$(NBE_MK_DPDKPATH) -I$(NBE_MK_INCPATH) $(CFLAGS) $(EXTRA_CFLAGS)
-	@cp -f $(basename $@).o $(NBE_MK_OBJPATH)/$(OBJ)
+	@cp -f $(basename $@).o $(NBE_MK_OBJPATH)/$(DPDKOBJ)

--- a/ndr.dpdkshl.mk
+++ b/ndr.dpdkshl.mk
@@ -1,3 +1,5 @@
+$(DPDKSHL) ?= $(NAME)
+
 SRCDIR := $(NBE_ROOT)/$S
 
 .PHONY: build
@@ -36,7 +38,7 @@ $(INCS):
 
 lklib:
 	@[ -d $(NBE_DPDKPATH) ] && cp -Lr $(NBE_DPDKPATH)/lib/* $(NBE_MK_DPDKPATH)/.
-	@gcc -o lib$(SHLIB).so $(EXTLIST) $(SRCLIST) -L$(NBE_LIBPATH) -L$(NBE_MK_DPDKPATH) $(NBE_LIBS) $(NBE_DPDKLIBS) $(LIBLIST) -shared -fPIC -DPIC
+	@gcc -o lib$(DPDKSHL).so $(EXTLIST) $(SRCLIST) -L$(NBE_LIBPATH) -L$(NBE_MK_DPDKPATH) $(NBE_LIBS) $(NBE_DPDKLIBS) $(LIBLIST) -shared -fPIC -DPIC
 
 cplib:
-	@cp -f lib$(SHLIB).so $(NBE_LIBPATH)
+	@cp -f lib$(DPDKSHL).so $(NBE_LIBPATH)

--- a/ndr.kext.mk
+++ b/ndr.kext.mk
@@ -1,3 +1,5 @@
+$(KEXT) ?= $(NAME)
+
 SRCDIR := $(NBE_ROOT)/$S
 
 .PHONY: build

--- a/ndr.kmod.mk
+++ b/ndr.kmod.mk
@@ -1,3 +1,5 @@
+$(KMOD) ?= $(NAME)
+
 SRCDIR := $(NBE_ROOT)/$S
 
 KVER ?= $(shell uname -r)

--- a/ndr.lib.mk
+++ b/ndr.lib.mk
@@ -1,3 +1,5 @@
+$(LIB) ?= $(NAME)
+
 SRCDIR := $(NBE_ROOT)/$S
 
 .PHONY: build

--- a/ndr.obj.mk
+++ b/ndr.obj.mk
@@ -1,3 +1,5 @@
+$(OBJ) = $(NAME)
+
 SRCDIR := $(NBE_ROOT)/$S
 
 .PHONY: build

--- a/ndr.shlib.mk
+++ b/ndr.shlib.mk
@@ -1,3 +1,5 @@
+$(SHLIB) ?= $(NAME)
+
 SRCDIR := $(NBE_ROOT)/$S
 
 .PHONY: build


### PR DESCRIPTION
- Make available to use only $(NAME) symbol to build targets that
generate results named as same.

Resolves: #64