### PR TITLE
build: fix missing -fPIC -DPIC flags for '*.pic.mk'.

### DIFF
--- a/dpdk.pic.mk
+++ b/dpdk.pic.mk
@@ -21,10 +21,10 @@ $(HDRS)::
 
 $(ASMS)::
 	@[ -d $(NBE_DPDKPATH) ] && cp -Lr $(NBE_DPDKPATH)/include/* $(NBE_MK_DPDKPATH)/.
-	@gcc -c $(SRCDIR)/$@ -I$(NBE_INCPATH) -I$(NBE_MK_DPDKPATH) -I$(NBE_MK_INCPATH) $(CFLAGS) $(EXTRA_CFLAGS)
+	@gcc -c $(SRCDIR)/$@ -I$(NBE_INCPATH) -I$(NBE_MK_DPDKPATH) -I$(NBE_MK_INCPATH) $(CFLAGS) $(EXTRA_CFLAGS) -fPIC -DPIC
 	@cp -f $(basename $@).o $(NBE_MK_PICPATH)/$(PIC)
 
 $(SRCS)::
 	@[ -d $(NBE_DPDKPATH) ] && cp -Lr $(NBE_DPDKPATH)/include/* $(NBE_MK_DPDKPATH)/.
-	@gcc -c $(SRCDIR)/$@ -I$(NBE_INCPATH) -I$(NBE_MK_DPDKPATH) -I$(NBE_MK_INCPATH) $(CFLAGS) $(EXTRA_CFLAGS)
+	@gcc -c $(SRCDIR)/$@ -I$(NBE_INCPATH) -I$(NBE_MK_DPDKPATH) -I$(NBE_MK_INCPATH) $(CFLAGS) $(EXTRA_CFLAGS) -fPIC -DPIC
 	@cp -f $(basename $@).o $(NBE_MK_PICPATH)/$(PIC)

--- a/ndr.pic.mk
+++ b/ndr.pic.mk
@@ -19,9 +19,9 @@ $(HDRS)::
 	@cp -f $(SRCDIR)/$@ $(NBE_MK_INCPATH)
 
 $(ASMS)::
-	@gcc -c $(SRCDIR)/$@ -I$(NBE_INCPATH) -I$(NBE_MK_INCPATH) $(CFLAGS) $(EXTRA_CFLAGS)
+	@gcc -c $(SRCDIR)/$@ -I$(NBE_INCPATH) -I$(NBE_MK_INCPATH) $(CFLAGS) $(EXTRA_CFLAGS) -fPIC -DPIC
 	@cp -f $(basename $@).o $(NBE_MK_PICPATH)/$(PIC)
 
 $(SRCS)::
-	@gcc -c $(SRCDIR)/$@ -I$(NBE_INCPATH) -I$(NBE_MK_INCPATH) $(CFLAGS) $(EXTRA_CFLAGS)
+	@gcc -c $(SRCDIR)/$@ -I$(NBE_INCPATH) -I$(NBE_MK_INCPATH) $(CFLAGS) $(EXTRA_CFLAGS) -fPIC -DPIC
 	@cp -f $(basename $@).o $(NBE_MK_PICPATH)/$(PIC)


### PR DESCRIPTION
- Fix missing -fPIC -DPIC flags for '*.pic.mk'.

Resolves: #72