### PR TITLE
build: ndr.coverage.mk causes a build failure.

### DIFF
--- a/ndr.coverage.mk
+++ b/ndr.coverage.mk
@@ -46,4 +46,4 @@ gcovgen::
 
 gcovcp::
 	@cp -f $(foreach COVFILE, $(COVFILES), ./$(notdir $(COVFILE)).gcov) $(NBE_COVPATH)/$(COVERAGE)
-	@$(NBE_SCRIPTS)/nbs.recover.sh $(NBE_PATHLOG_RESTORE) $(NBE_COVPATH)/$(COVERAGE)
+	@$(NBE_SCRIPTS)/nbs.restore.path $(NBE_PATHLOG_RESTORE) $(NBE_COVPATH)/$(COVERAGE)


### PR DESCRIPTION
- Fix an invalid script path in the 'ndr.coverage.mk'.

Resolves: #75